### PR TITLE
Update workflow to use artifact actions v4, update actions/cache from…

### DIFF
--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -58,4 +58,6 @@ jobs:
     - name: Save Test Result JSON
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ matrix.suite }}-results
         path: spec/results
+        overwrite: true

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
     - name: Setup caching
@@ -56,6 +56,6 @@ jobs:
     - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
       run: bundle exec inspec_tools compliance -j spec/results/${{ matrix.suite }}-test-result.json -f threshold.${{ matrix.suite }}.yml
     - name: Save Test Result JSON
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: spec/results

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -60,4 +60,3 @@ jobs:
       with:
         name: ${{ matrix.suite }}-results
         path: spec/results
-        overwrite: true

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -25,13 +25,13 @@ jobs:
       fail-fast: false
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.1'
     - name: Setup caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
       - name: Setup caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -56,6 +56,6 @@ jobs:
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
         run: bundle exec inspec_tools compliance -j spec/results/${{ matrix.suite }}-test-result.json -f threshold.${{ matrix.suite }}.yml
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: spec/results

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -60,4 +60,3 @@ jobs:
         with:
           name: ${{ matrix.suite }}-results
           path: spec/results
-          overwrite: true

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -58,4 +58,6 @@ jobs:
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.suite }}-results
           path: spec/results
+          overwrite: true

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Add jq for output formatting
         run: brew install jq
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
       - name: Setup caching


### PR DESCRIPTION
… v2 to v4, and replaced archived actions/setup-ruby with ruby/setup-ruby

Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Also actions/setup-ruby is archived and has been recommended instead to use ruby/setup-ruby
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)